### PR TITLE
Add vcloud post-proc for ci/cd & new box path dev

### DIFF
--- a/packer/centos/centos.json
+++ b/packer/centos/centos.json
@@ -1,6 +1,7 @@
 {
   "variables": {
-    "version": ""
+    "cloud_token": "{{ env `VAGRANT_CLOUD_TOKEN` }}",
+    "version": "0.9.{{timestamp}}"
   },
   "builders": [
     {
@@ -53,12 +54,23 @@
     },
     {
       "type": "shell",
-      "scripts": "./scripts/cleanup.sh"
+      "scripts": "./scripts/cleanup.sh",
+      "execute_command": "echo 'packer' | sudo -S sh -c '{{ .Vars }} {{ .Path }}'"
     }
   ],
-  "post-processors": [{
-    "type": "vagrant",
-    "compression_level": "8",
-    "output": "../output/{{.Provider}}-centos-{{timestamp}}.box"
-  }]
+  "post-processors": [
+    [
+      {
+        "type": "vagrant",
+        "compression_level": "8",
+        "output": "../_output/{{.Provider}}-dev-centos7-{{timestamp}}.box"
+      },
+      {
+        "type": "vagrant-cloud",
+        "box_tag": "thremulation-station/dev-centos7",
+        "access_token": "{{user `cloud_token`}}",
+        "version": "{{user `version`}}"
+      }
+    ]
+  ]
 }

--- a/packer/elastomic/elastomic.json
+++ b/packer/elastomic/elastomic.json
@@ -1,6 +1,7 @@
 {
   "variables": {
-    "version": ""
+    "cloud_token": "{{ env `VAGRANT_CLOUD_TOKEN` }}",
+    "version": "0.9.{{timestamp}}"
   },
   "builders": [
     {
@@ -61,12 +62,23 @@
     },
     {
       "type": "shell",
-      "scripts": "./scripts/cleanup.sh"
+      "scripts": "./scripts/cleanup.sh",
+      "execute_command": "echo 'packer' | sudo -S sh -c '{{ .Vars }} {{ .Path }}'"
     }
   ],
-  "post-processors": [{
-    "type": "vagrant",
-    "compression_level": "8",
-    "output": "../output/{{.Provider}}-elastomic-{{timestamp}}.box"
-  }]
+  "post-processors": [
+    [
+      {
+        "type": "vagrant",
+        "compression_level": "8",
+        "output": "../_output/{{.Provider}}-dev-elastomic-{{timestamp}}.box"
+      },
+      {
+        "type": "vagrant-cloud",
+        "box_tag": "thremulation-station/dev-elastomic",
+        "access_token": "{{user `cloud_token`}}",
+        "version": "{{user `version`}}"
+      }
+    ]
+  ]
 }

--- a/packer/windows10/windows10.json
+++ b/packer/windows10/windows10.json
@@ -1,4 +1,12 @@
 {
+  "variables": {
+    "iso_md5": "6cd2f47f2c32faa7be85f1dc81af3220",
+    "iso_path": "../_iso/10240.16384.150709-1700.TH1_CLIENTENTERPRISEEVAL_OEMRET_X64FRE_EN-US.ISO",
+    "switch_name": "Default Switch",
+    "cloud_token": "{{ env `VAGRANT_CLOUD_TOKEN` }}",
+    "version": "0.9.{{timestamp}}"
+  },
+
   "builders": [
     {
       "communicator": "winrm",
@@ -44,14 +52,6 @@
       "winrm_username": "vagrant"
     }
   ],
-  "post-processors": [
-    {
-      "keep_input_artifact": false,
-      "output": "../output/{{.Provider}}-windows10-{{timestamp}}.box",
-      "type": "vagrant",
-      "vagrantfile_template": "vagrantfile.template"
-    }
-  ],
   "provisioners": [
     {
       "scripts": [
@@ -83,10 +83,20 @@
       "type": "powershell"
     }
   ],
-  "variables": {
-    "iso_md5": "6cd2f47f2c32faa7be85f1dc81af3220",
-    "iso_path": "../_iso/10240.16384.150709-1700.TH1_CLIENTENTERPRISEEVAL_OEMRET_X64FRE_EN-US.ISO",
-    "switch_name": "Default Switch"
-  }
+  "post-processors": [
+    [
+      {
+        "type": "vagrant",
+        "compression_level": "8",
+        "output": "../_output/{{.Provider}}-dev-windows10-{{timestamp}}.box"
+      },
+      {
+        "type": "vagrant-cloud",
+        "box_tag": "thremulation-station/dev-windows10",
+        "access_token": "{{user `cloud_token`}}",
+        "version": "{{user `version`}}"
+      }
+    ]
+  ]
 }
 

--- a/vagrant/Vagrantfile
+++ b/vagrant/Vagrantfile
@@ -1,7 +1,7 @@
 Vagrant.configure("2") do |config|
 
   config.vm.define "ts.elastomic", primary: true do |cfg|
-    cfg.vm.box = "thremulation-station/elastomic"
+    cfg.vm.box = "thremulation-station/dev-elastomic"
     cfg.vm.box_version = "0.9.0"
     cfg.vm.hostname = "elastomic"
     cfg.disksize.size = "256GB"
@@ -32,7 +32,7 @@ Vagrant.configure("2") do |config|
   end
 
   config.vm.define "ts.windows10" do |cfg|
-    cfg.vm.box = "thremulation-station/windows10"
+    cfg.vm.box = "thremulation-station/dev-windows10"
     cfg.vm.box_version = "0.9.2"
     cfg.vm.hostname = "windows10"
     cfg.vbguest.auto_update = false
@@ -48,7 +48,7 @@ Vagrant.configure("2") do |config|
   end
 
   config.vm.define "ts.centos7" do |cfg|
-    cfg.vm.box = "thremulation-station/centos7"
+    cfg.vm.box = "thremulation-station/dev-centos7"
     cfg.vm.box_version = "0.9.0"
     cfg.vm.hostname = "centos7"
     cfg.vbguest.auto_update = false


### PR DESCRIPTION
To pave way for simple ci-cd workflow:

- adds vcloud post-processor along with local .box files
- fixes cleanup script permissions (wasn't executing)
-  update Vagrant file box paths to devel version (`thremulation-station/dev-<boxname>`)