### PR TITLE
Update kibana.yml

### DIFF
--- a/packer/elastomic/ansible/files/kibana.yml
+++ b/packer/elastomic/ansible/files/kibana.yml
@@ -116,5 +116,5 @@ elasticsearch.hosts: "http://localhost:9200"
 xpack.security.enabled: true
 telemetry.enabled: false
 telemetry.optIn: false
-xpack.ingestManager.fleet.tlsCheckDisabled: true
+xpack.fleet.agents.tlsCheckDisabled: tru
 xpack.encryptedSavedObjects.encryptionKey: 'fhjskloppd678ehkdfdlliverpoolfcr'


### PR DESCRIPTION
This might need to be changed to xpack.fleet.agents.tlsCheckDisabled: true from xpack.ingestManager.fleet.tlsCheckDisabled: true here https://github.com/thremulation-station/thremulation-station/blob/main/packer/elastomic/ansible/files/kibana.yml

Haven't tested, but https://www.elastic.co/guide/en/kibana/current/fleet-settings-kb.html#_fleet_settings

xpack.fleet.agents.tlsCheckDisabled | Set to true to allow Fleet to run on a Kibana instance without TLS enabled.