### PR TITLE
Updated agent scripts for Elastic 7.14

### DIFF
--- a/vagrant/scripts/install-ea-linux.sh
+++ b/vagrant/scripts/install-ea-linux.sh
@@ -2,7 +2,7 @@
 
 set -o pipefail
 
-STACK_VER="${ELASTIC_STACK_VERSION:-7.10.1}"
+STACK_VER="${ELASTIC_STACK_VERSION:-7.14.0}"
 KIBANA_URL="${KIBANA_URL:-http://127.0.0.1:5601}"
 KIBANA_AUTH="${KIBANA_AUTH:-}"
 
@@ -19,7 +19,7 @@ function download_and_install_agent() {
     cd "$(mktemp -d)"
     curl --silent -LJ "${AGENT_URL}" | tar xzf -
     cd "$(basename "$(basename "${AGENT_URL}")" .tar.gz)"
-    sudo ./elastic-agent install --force --insecure --kibana-url="${KIBANA_URL}" --enrollment-token="${ENROLLMENT_TOKEN}"
+    sudo ./elastic-agent install --force --insecure --url="${FLEET_SERVER_URL}" --enrollment-token="${ENROLLMENT_TOKEN}"
 
     # Cleanup temporary directory
     cd ..
@@ -30,18 +30,20 @@ function download_and_install_agent() {
 function get_enrollment_token() {
     declare -a AUTH=()
     declare -a HEADERS=(
-        "-H" "Content-Type: application/json"
+        "-H" "Content-Type: application/json",
+        "-H" "kbn-xsrf: 7.14.0"
     )
 
     if [ -n "${KIBANA_AUTH}" ]; then
         AUTH=("-u" "${KIBANA_AUTH}")
     fi
 
-    response=$(curl --silent "${AUTH[@]}" "${HEADERS[@]}" "${KIBANA_URL}/api/fleet/enrollment-api-keys")
-    enrollment_key_id=$(echo -n "${response}" | jq -r '.list[] | select(.name | startswith("Default")) | .id' )
-    enrollment_key=$(curl --silent "${AUTH[@]}" "${HEADERS[@]}" "${KIBANA_URL}/api/fleet/enrollment-api-keys/${enrollment_key_id}" | jq -r '.item.api_key')
+    POLICY_ID=$(curl --silent -XGET "${AUTH[@]}" "${HEADERS[@]}" "${KIBANA_URL}/api/fleet/agent_policies" | jq --raw-output '.items[] | select(.name | startswith("Default policy")) | .id')
 
-    echo -n "${enrollment_key}"
+    ENROLLMENT_TOKEN=$(curl --silent -XGET "${AUTH[@]}" "${HEADERS[@]}" "${KIBANA_URL}/api/fleet/enrollment-api-keys" | jq --arg POLICY_ID "$POLICY_ID" -r '.list[] | select(.policy_id==$POLICY_ID) | .api_key')
+
+-   echo -n "${enrollment_key}"
+
 }
 
 install_jq


### PR DESCRIPTION
Here are the agent scripts for victim boxes. 

Some changes with the Fleet API's and we do some checks to make sure that the agents are enrolling in the right policies. 

Makes use of a new environment variable for the fleet server running on Elastomic.

Solves #73 