### PR TITLE
Mounts and installs guestadditions for VirtualBox

### DIFF
--- a/packer/vbox-centos7/ansible/centos-playbook.yml
+++ b/packer/vbox-centos7/ansible/centos-playbook.yml
@@ -369,11 +369,12 @@
         state: restarted
         
     - name: Mount Guest Additions ISO
-      path: /mnt/
-      src: /home/vagrant/VBoxGuestAdditions_6.1.2.6.iso
-      fstype: iso9660
-      opts: ro
-      state: mounted
+      mount:
+        path: /mnt/
+        src: /home/vagrant/VBoxGuestAdditions_6.1.2.6.iso
+        fstype: iso9660
+        opts: ro
+        state: mounted
 
     - name: Install Guest Additions
       shell: /mnt/VBoxGuestAdditions.run

--- a/packer/vbox-centos7/ansible/centos-playbook.yml
+++ b/packer/vbox-centos7/ansible/centos-playbook.yml
@@ -52,7 +52,7 @@
           - kernel-devel
           - make
           - perl
-          -bzip2
+          - bzip2
 
     - name: Install System Tools
       yum:

--- a/packer/vbox-centos7/ansible/centos-playbook.yml
+++ b/packer/vbox-centos7/ansible/centos-playbook.yml
@@ -376,6 +376,6 @@
       opts: ro
       state: mounted
 
-    - name: Install Guest Additions
+    - name: Install GuestAdditions
       shell: /mnt/VBoxGuestAdditions.run
      

--- a/packer/vbox-centos7/ansible/centos-playbook.yml
+++ b/packer/vbox-centos7/ansible/centos-playbook.yml
@@ -377,5 +377,5 @@
         state: mounted
 
     - name: Install Guest Additions
-      shell: /mnt/VBoxGuestAdditions.run
+      shell: /mnt/VBoxLinuxAdditions.run
      

--- a/packer/vbox-centos7/ansible/centos-playbook.yml
+++ b/packer/vbox-centos7/ansible/centos-playbook.yml
@@ -369,6 +369,7 @@
         state: restarted
         
     - name: Mount Guest Additions ISO
+      path: /mnt/
       src: /home/vagrant/VBoxGuestAdditions_6.1.2.6.iso
       fstype: iso9660
       opts: ro

--- a/packer/vbox-centos7/ansible/centos-playbook.yml
+++ b/packer/vbox-centos7/ansible/centos-playbook.yml
@@ -41,7 +41,7 @@
       command: yum clean all
 
 
-    - name: Install Dependencies for VirtualBox GuestAdditions
+    - name: Install Dependencies for VirtualBox Guest Additions
       yum:
         name: "{{ packages }}"
         state: present
@@ -370,12 +370,12 @@
         name: sshd
         state: restarted
         
-    - name: Mount GuestAdditions ISO
+    - name: Mount Guest Additions ISO
       src: /home/vagrant/VBoxGuestAdditions_6.1.2.6.iso
       fstype: iso9660
       opts: ro
       state: mounted
 
-    - name: Install GuestAdditions
+    - name: Install Guest Additions
       shell: /mnt/VBoxGuestAdditions.run
      

--- a/packer/vbox-centos7/ansible/centos-playbook.yml
+++ b/packer/vbox-centos7/ansible/centos-playbook.yml
@@ -371,7 +371,7 @@
     - name: Mount Guest Additions ISO
       mount:
         path: /mnt/
-        src: /home/vagrant/VBoxGuestAdditions_6.1.2.6.iso
+        src: /home/vagrant/VBoxGuestAdditions_6.1.26.iso
         fstype: iso9660
         opts: ro
         state: mounted

--- a/packer/vbox-centos7/ansible/centos-playbook.yml
+++ b/packer/vbox-centos7/ansible/centos-playbook.yml
@@ -40,6 +40,21 @@
     - name: Clean Yum Cache
       command: yum clean all
 
+
+    - name: Install Dependencies for VirtualBox GuestAdditions
+      yum:
+        name: "{{ packages }}"
+        state: present
+      vars:
+        packages:
+          - patch
+          - gcc
+          - kernel-headers
+          - kernel-devel
+          - make
+          - perl
+          -bzip2
+
     - name: Install System Tools
       yum:
         name: "{{ packages }}"
@@ -354,3 +369,13 @@
       systemd:
         name: sshd
         state: restarted
+        
+    - name: Mount GuestAdditions ISO
+      src: /home/vagrant/VBoxGuestAdditions_6.1.2.6.iso
+      fstype: iso9660
+      opts: ro
+      state: mounted
+
+    - name: Install Guest Additions
+      shell: /mnt/VBoxGuestAdditions.run
+     

--- a/packer/vbox-centos7/ansible/centos-playbook.yml
+++ b/packer/vbox-centos7/ansible/centos-playbook.yml
@@ -47,7 +47,6 @@
         state: present
       vars:
         packages:
-          - patch
           - gcc
           - kernel-headers
           - kernel-devel
@@ -68,7 +67,6 @@
           - git
           - wget
           - golang
-          - bzip2
 
     - name: Start Firewalld Service
       systemd:

--- a/packer/vbox-elastic/ansible/elastic-playbook.yml
+++ b/packer/vbox-elastic/ansible/elastic-playbook.yml
@@ -61,7 +61,7 @@
           - kernel-devel
           - make
           - perl
-          -bzip2
+          - bzip2
           
     - name: Reboot for GuestAdditions
       reboot:

--- a/packer/vbox-elastic/ansible/elastic-playbook.yml
+++ b/packer/vbox-elastic/ansible/elastic-playbook.yml
@@ -356,7 +356,7 @@
     - name: Mount Guest Additions ISO
       mount:
         path: /mnt/
-        src: /home/vagrant/VBoxGuestAdditions_6.1.2.6.iso
+        src: /home/vagrant/VBoxGuestAdditions_6.1.26.iso
         fstype: iso9660
         opts: ro
         state: mounted

--- a/packer/vbox-elastic/ansible/elastic-playbook.yml
+++ b/packer/vbox-elastic/ansible/elastic-playbook.yml
@@ -49,6 +49,26 @@
     - name: Clean Yum Cache
       command: yum clean all
 
+
+    - name: Install Dependencies for VirtualBox GuestAdditions
+      yum:
+        name: "{{ packages }}"
+        state: present
+      vars:
+        packages:
+          - patch
+          - gcc
+          - kernel-headers
+          - kernel-devel
+          - make
+          - perl
+          -bzip2
+          
+    - name: Reboot for GuestAdditions
+      reboot:
+        reboot_timeout: 300
+
+
     - name: Install System Tools
       yum:
         name: "{{ packages }}"
@@ -85,6 +105,14 @@
       firewalld:
         zone: public
         port: 5601/tcp
+        permanent: true
+        immediate: true
+        state: enabled
+        
+    - name: Add Fleet Server Rule
+      firewalld:
+        zone: public
+        port: 8220/tcp
         permanent: true
         immediate: true
         state: enabled
@@ -325,3 +353,12 @@
       systemd:
         name: sshd
         state: restarted
+        
+    - name: Mount Guest Additions ISO
+      src: /home/vagrant/VBoxGuestAdditions_6.1.2.6.iso
+      fstype: iso9660
+      opts: ro
+      state: mounted
+      
+    - name: Install Guest Additions
+      shell: /mnt/VBoxGuestAdditions.run

--- a/packer/vbox-elastic/ansible/elastic-playbook.yml
+++ b/packer/vbox-elastic/ansible/elastic-playbook.yml
@@ -362,4 +362,4 @@
         state: mounted
       
     - name: Install Guest Additions
-      shell: /mnt/VBoxGuestAdditions.run
+      shell: /mnt/VBoxLinuxAdditions.run

--- a/packer/vbox-elastic/ansible/elastic-playbook.yml
+++ b/packer/vbox-elastic/ansible/elastic-playbook.yml
@@ -56,7 +56,6 @@
         state: present
       vars:
         packages:
-          - patch
           - gcc
           - kernel-headers
           - kernel-devel

--- a/packer/vbox-elastic/ansible/elastic-playbook.yml
+++ b/packer/vbox-elastic/ansible/elastic-playbook.yml
@@ -354,11 +354,12 @@
         state: restarted
         
     - name: Mount Guest Additions ISO
-      path: /mnt/
-      src: /home/vagrant/VBoxGuestAdditions_6.1.2.6.iso
-      fstype: iso9660
-      opts: ro
-      state: mounted
+      mount:
+        path: /mnt/
+        src: /home/vagrant/VBoxGuestAdditions_6.1.2.6.iso
+        fstype: iso9660
+        opts: ro
+        state: mounted
       
     - name: Install Guest Additions
       shell: /mnt/VBoxGuestAdditions.run

--- a/packer/vbox-elastic/ansible/elastic-playbook.yml
+++ b/packer/vbox-elastic/ansible/elastic-playbook.yml
@@ -50,7 +50,7 @@
       command: yum clean all
 
 
-    - name: Install Dependencies for VirtualBox GuestAdditions
+    - name: Install Dependencies for VirtualBox Guest Additions
       yum:
         name: "{{ packages }}"
         state: present
@@ -354,11 +354,11 @@
         name: sshd
         state: restarted
         
-    - name: Mount GuestAdditions ISO
+    - name: Mount Guest Additions ISO
       src: /home/vagrant/VBoxGuestAdditions_6.1.2.6.iso
       fstype: iso9660
       opts: ro
       state: mounted
       
-    - name: Install GuestAdditions
+    - name: Install Guest Additions
       shell: /mnt/VBoxGuestAdditions.run

--- a/packer/vbox-elastic/ansible/elastic-playbook.yml
+++ b/packer/vbox-elastic/ansible/elastic-playbook.yml
@@ -354,6 +354,7 @@
         state: restarted
         
     - name: Mount Guest Additions ISO
+      path: /mnt/
       src: /home/vagrant/VBoxGuestAdditions_6.1.2.6.iso
       fstype: iso9660
       opts: ro

--- a/packer/vbox-elastic/ansible/elastic-playbook.yml
+++ b/packer/vbox-elastic/ansible/elastic-playbook.yml
@@ -354,11 +354,11 @@
         name: sshd
         state: restarted
         
-    - name: Mount Guest Additions ISO
+    - name: Mount GuestAdditions ISO
       src: /home/vagrant/VBoxGuestAdditions_6.1.2.6.iso
       fstype: iso9660
       opts: ro
       state: mounted
       
-    - name: Install Guest Additions
+    - name: Install GuestAdditions
       shell: /mnt/VBoxGuestAdditions.run


### PR DESCRIPTION
This will install GuestAdditions on the `elastic` and `centos7` box.  still going to pursue getting the kernel headers installed as it seems like that takes a good chunk of the build time. 