### PR TITLE
Dev red debian

### DIFF
--- a/packer/vbox-redops/ansible/debian11-redops-playbook.yml
+++ b/packer/vbox-redops/ansible/debian11-redops-playbook.yml
@@ -88,13 +88,13 @@
         - /home/vagrant/Pictures
         - /home/vagrant/Videos
 
-   - name: Install XRDP
-     apt:
-       name: xrdp
-       state: present
+    - name: Install XRDP
+      apt:
+        name: xrdp
+        state: present
 
-   - name: Add XRDP user to SSL-cert group
-     command: adduser xrdp ssl-cert
+    - name: Add XRDP user to SSL-cert group
+      command: adduser xrdp ssl-cert
 
    - name: Add XRDP rule
       ufw:

--- a/packer/vbox-redops/ansible/debian11-redops-playbook.yml
+++ b/packer/vbox-redops/ansible/debian11-redops-playbook.yml
@@ -84,7 +84,7 @@
       ufw:
          rule: allow
          port: '4545'
-         proto: tcp
+         proto: udp
          state: enabled
          
     - name: Add Operator HTTP Firewall Rule

--- a/packer/vbox-redops/ansible/debian11-redops-playbook.yml
+++ b/packer/vbox-redops/ansible/debian11-redops-playbook.yml
@@ -1,0 +1,227 @@
+---
+  - hosts: all
+    become: yes
+    gather_facts: no
+
+    tasks:
+  
+    - name: Import APT Keys
+      apt_key:
+        state: present
+        url: "{{ item }}"
+      loop:
+        - https://artifacts.elastic.co/GPG-KEY-elasticsearch
+        - https://packages.microsoft.com/keys/microsoft.asc
+      retries: 5
+#    - name: Add EPEL Repository
+#      yum:
+#        name: epel-release
+
+
+    - name: Add Microsoft Repository
+      apt_repository:
+        repo: deb [arch=amd64] https://packages.microsoft.com/debian/10/prod/ buster main
+        state: present
+        update_cache: yes
+#        description: Microsoft Repo for RHEL-based
+#        enabled: yes
+#        gpgcheck: yes
+#        baseurl: https://packages.microsoft.com/rhel/7/prod/
+#        gpgkey: https://packages.microsoft.com/keys/microsoft.asc
+        filename: packages-microsoft-prod
+
+    - name: Clean Cache
+      command: apt-get clean
+
+    - name: Refresh apt-cache
+      command: apt-get update
+
+    - name: Install System Tools
+      apt:
+        name: "{{ packages }}"
+        state: present
+      vars:
+        packages:
+          - ufw
+          - vim
+          - nano
+          - tmux
+          - git
+          - wget
+          - golang
+
+    - name: Prep to start services
+      command: systemctl daemon-reload
+
+    - name: Start Firewalld Service
+      command: systemctl start ufw
+
+#    - name: Start Firewalld Service
+#      systemd:
+#        name: firewalld
+#        state: started
+#        enabled: yes
+
+
+
+####################################
+# Install XCFE
+
+#    - name: Install X Window System
+#      command: yum groupinstall "X Window System" -y
+
+    - name: Install XFCE 4
+      apt:
+        name: xfce4
+        state: present
+
+#    - name: Install XFCE
+#      command: yum groupinstall "Xfce" -y
+
+#    - name: Set Graphic Target
+#      file:
+#        src: /usr/lib/systemd/system/graphical.target
+#        dest: /etc/systemd/system/default.target
+#        state: link
+
+    - name: Install XRDP
+      apt:
+        name: xrdp
+        state: present
+
+    - name: Add XRDP user to SSL-cert group
+      command: adduser xrdp ssl-cert
+
+
+#    - name: Reboot to set graphical target
+#      reboot:
+#        reboot_timeout: 300
+
+####################################
+# Operator 
+    - name: Add Pneuma Firewall Rule
+      ufw:
+         rule: allow
+         port: '2323'
+         proto: tcp
+         state: enabled
+
+#    - name: Install XRDP
+#      yum:
+#        name: xrdp
+#        state: present
+
+    - name: Add XRDP rule
+      ufw:
+         rule: allow
+         port: '3389'
+         proto: tcp
+         state: enabled
+
+    - name: Add SSH Rule for Vagrant
+      ufw:
+         rule: allow
+         port: '22'
+         proto: tcp
+         state: enabled
+
+
+    - name: Reload
+      command: systemctl daemon-reload
+
+    - name: Start XRDP Service
+      command: systemctl enable xrdp
+
+
+###################################
+# Powershell
+###################################
+
+    - name: Install Powershell
+      apt:
+        name: powershell
+        state: present
+
+    - name: Enable Powershell Remoting
+      command: pwsh -Command {Enable-PSRemoting -Force}
+
+
+###################################
+# SSH Configuration
+###################################
+
+    - name: Uncomment Pass Auth Yes
+      lineinfile:
+        path: /etc/ssh/sshd_config
+        regexp: '^#PasswordAuthentication\s+yes'
+        line: PasswordAuthentication yes
+        owner: root
+        group: root
+        mode: '0600'
+
+    - name: Comment out Passauth No
+      lineinfile:
+        path: /etc/ssh/sshd_config
+        regexp: '^PasswordAuthentication\s+no'
+        line: '# PasswordAuthentication no'
+        owner: root
+        group: root
+        mode: '0600'
+
+    - name: Allow SSH Pubkey Auth
+      lineinfile:
+        path: /etc/ssh/sshd_config
+        regexp: '^#PubkeyAuthentication\s+yes'
+        line: 'PubkeyAuthentication yes'
+        owner: root
+        group: root
+        mode: '0600'
+
+    - name: Add PS Subsystem to PS remote over SSH
+      lineinfile:
+        path: /etc/ssh/sshd_config
+        line: 'Subsystem powershell /usr/bin/pwsh -sshs -NoLogo'
+        create: yes
+        owner: root
+        group: root
+        mode: '0600'
+
+    - name: Create Vagrant User SSH Directory
+      file:
+        path: /home/vagrant/.ssh
+        state: directory
+        owner: vagrant
+        mode: '0700'
+
+    - name: Retrieve Default Vagrant Pub Key
+      command: wget --no-check-certificate https://raw.github.com/mitchellh/vagrant/master/keys/vagrant.pub -O /home/vagrant/.ssh/authorized_keys
+
+    # - name: Copy Authorizedkeys File
+    #   copy:
+    #     src: ./files/authorizedkeys
+    #     dest: /home/vagrant/.ssh/authorizedkeys
+    #     owner: vagrant
+    #     group: vagrant
+    #     mode: '0600'
+  
+    - name: Update Permissions of SSH Key
+      file:
+        path: /home/vagrant/.ssh/authorized_keys
+        state: file
+        owner: vagrant
+        mode: '0600'
+  
+    - name: Add AuthorizedKeysFile to Config
+      lineinfile:
+        path: /etc/ssh/sshd_config
+        regexp: '^AuthorizedKeysFile\s+\.ssh/authorized_keys'
+        line: 'AuthorizedKeysFile %h/.ssh/authorized_keys'
+        owner: root
+        group: root
+        mode: '0600'
+
+    - name: Restart sshd service
+      systemd:
+        name: sshd
+        state: restarted
+     

--- a/packer/vbox-redops/ansible/debian11-redops-playbook.yml
+++ b/packer/vbox-redops/ansible/debian11-redops-playbook.yml
@@ -49,6 +49,9 @@
           - git
           - wget
           - golang
+          - firefox-esr
+          - gedit
+          - terminator
 
     - name: Prep to start services
       command: systemctl daemon-reload

--- a/packer/vbox-redops/ansible/debian11-redops-playbook.yml
+++ b/packer/vbox-redops/ansible/debian11-redops-playbook.yml
@@ -13,9 +13,6 @@
         - https://artifacts.elastic.co/GPG-KEY-elasticsearch
         - https://packages.microsoft.com/keys/microsoft.asc
       retries: 5
-#    - name: Add EPEL Repository
-#      yum:
-#        name: epel-release
 
 
     - name: Add Microsoft Repository
@@ -23,11 +20,6 @@
         repo: deb [arch=amd64] https://packages.microsoft.com/debian/10/prod/ buster main
         state: present
         update_cache: yes
-#        description: Microsoft Repo for RHEL-based
-#        enabled: yes
-#        gpgcheck: yes
-#        baseurl: https://packages.microsoft.com/rhel/7/prod/
-#        gpgkey: https://packages.microsoft.com/keys/microsoft.asc
         filename: packages-microsoft-prod
 
     - name: Clean Cache
@@ -59,53 +51,53 @@
     - name: Start Firewalld Service
       command: systemctl start ufw
 
-#    - name: Start Firewalld Service
-#      systemd:
-#        name: firewalld
-#        state: started
-#        enabled: yes
-
 
 
 ####################################
 # Install XCFE
-
-#    - name: Install X Window System
-#      command: yum groupinstall "X Window System" -y
 
     - name: Install XFCE 4
       apt:
         name: xfce4
         state: present
 
-#    - name: Install XFCE
-#      command: yum groupinstall "Xfce" -y
+    #- name: Install XRDP
+    #  apt:
+    #    name: xrdp
+    #    state: present
 
-#    - name: Set Graphic Target
-#      file:
-#        src: /usr/lib/systemd/system/graphical.target
-#        dest: /etc/systemd/system/default.target
-#        state: link
+    #- name: Add XRDP user to SSL-cert group
+    #  command: adduser xrdp ssl-cert
 
-    - name: Install XRDP
-      apt:
-        name: xrdp
-        state: present
-
-    - name: Add XRDP user to SSL-cert group
-      command: adduser xrdp ssl-cert
-
-
-#    - name: Reboot to set graphical target
-#      reboot:
-#        reboot_timeout: 300
 
 ####################################
 # Operator 
-    - name: Add Pneuma Firewall Rule
+    - name: Add Operator TCP Firewall Rule
       ufw:
          rule: allow
          port: '2323'
+         proto: tcp
+         state: enabled
+
+         
+    - name: Add Operator UDP Firewall Rule
+      ufw:
+         rule: allow
+         port: '4545'
+         proto: tcp
+         state: enabled
+         
+    - name: Add Operator HTTP Firewall Rule
+      ufw:
+         rule: allow
+         port: '3391'
+         proto: tcp
+         state: enabled
+         
+    - name: Add Operator Reverse Shell Firewall Rule
+      ufw:
+         rule: allow
+         port: '3007'
          proto: tcp
          state: enabled
 
@@ -129,11 +121,11 @@
          state: enabled
 
 
-    - name: Reload
-      command: systemctl daemon-reload
+    #- name: Reload
+    #  command: systemctl daemon-reload
 
-    - name: Start XRDP Service
-      command: systemctl enable xrdp
+    #- name: Start XRDP Service
+    #  command: systemctl enable xrdp
 
 
 ###################################

--- a/packer/vbox-redops/ansible/debian11-redops-playbook.yml
+++ b/packer/vbox-redops/ansible/debian11-redops-playbook.yml
@@ -96,7 +96,7 @@
     - name: Add XRDP user to SSL-cert group
       command: adduser xrdp ssl-cert
 
-   - name: Add XRDP rule
+    - name: Add XRDP rule
       ufw:
          rule: allow
          port: '3389'

--- a/packer/vbox-redops/ansible/debian11-redops-playbook.yml
+++ b/packer/vbox-redops/ansible/debian11-redops-playbook.yml
@@ -60,6 +60,33 @@
       apt:
         name: xfce4
         state: present
+        
+    - name: Set Graphic Target
+      file:
+        src: /usr/lib/systemd/system/graphical.target
+        dest: /etc/systemd/system/default.target
+        state: link
+
+    - name: Reboot to bootstrap XFCE
+      reboot:
+        reboot_timeout: 300
+
+    - name: Create User Directories
+      file:
+        path: "{{ item }}"
+        state: directory
+        owner: vagrant
+        group: vagrant
+        mode: '0700'
+      loop:
+        - /home/vagrant/Desktop
+        - /home/vagrant/Downloads
+        - /home/vagrant/Templates
+        - /home/vagrant/Public
+        - /home/vagrant/Documents
+        - /home/vagrant/Music
+        - /home/vagrant/Pictures
+        - /home/vagrant/Videos
 
     #- name: Install XRDP
     #  apt:

--- a/packer/vbox-redops/ansible/debian11-redops-playbook.yml
+++ b/packer/vbox-redops/ansible/debian11-redops-playbook.yml
@@ -60,7 +60,18 @@
       apt:
         name: xfce4
         state: present
+
+    - name: Remove lightdm
+      apt:
+        name: lightdm
+        state: absent
         
+    - name: Install SDDM
+      apt:
+        name: sddm
+        state: present
+
+
     - name: Set Graphic Target
       file:
         src: /usr/lib/systemd/system/graphical.target

--- a/packer/vbox-redops/ansible/debian11-redops-playbook.yml
+++ b/packer/vbox-redops/ansible/debian11-redops-playbook.yml
@@ -61,17 +61,6 @@
         name: xfce4
         state: present
 
-    - name: Remove lightdm
-      apt:
-        name: lightdm
-        state: absent
-        
-    - name: Install SDDM
-      apt:
-        name: sddm
-        state: present
-
-
     - name: Set Graphic Target
       file:
         src: /usr/lib/systemd/system/graphical.target
@@ -99,14 +88,20 @@
         - /home/vagrant/Pictures
         - /home/vagrant/Videos
 
-    #- name: Install XRDP
-    #  apt:
-    #    name: xrdp
-    #    state: present
+   - name: Install XRDP
+     apt:
+       name: xrdp
+       state: present
 
-    #- name: Add XRDP user to SSL-cert group
-    #  command: adduser xrdp ssl-cert
+   - name: Add XRDP user to SSL-cert group
+     command: adduser xrdp ssl-cert
 
+   - name: Add XRDP rule
+      ufw:
+         rule: allow
+         port: '3389'
+         proto: tcp
+         state: enabled
 
 ####################################
 # Operator 
@@ -139,17 +134,6 @@
          proto: tcp
          state: enabled
 
-#    - name: Install XRDP
-#      yum:
-#        name: xrdp
-#        state: present
-
-    - name: Add XRDP rule
-      ufw:
-         rule: allow
-         port: '3389'
-         proto: tcp
-         state: enabled
 
     - name: Add SSH Rule for Vagrant
       ufw:

--- a/packer/vbox-redops/debian-11-redops.json
+++ b/packer/vbox-redops/debian-11-redops.json
@@ -77,8 +77,7 @@
         "scripts/sudoers.sh",
         "scripts/vagrant.sh",
         "scripts/systemd.sh",
-        "scripts/virtualbox.sh",
-        "scripts/xfce-settings.sh"
+        "scripts/virtualbox.sh"
         ]
       },
       

--- a/packer/vbox-redops/debian-11-redops.json
+++ b/packer/vbox-redops/debian-11-redops.json
@@ -91,7 +91,7 @@
         "type": "shell",
         "scripts": [
         "scripts/xfce-settings.sh",
-        "scripts": "scripts/cleanup.sh"
+        "scripts/cleanup.sh"
         ],
         "execute_command": "echo 'packer' | sudo -S sh -c '{{ .Vars }} {{ .Path }}'"
       }

--- a/packer/vbox-redops/debian-11-redops.json
+++ b/packer/vbox-redops/debian-11-redops.json
@@ -59,7 +59,7 @@
             "--vram",
             "32"
           ]
-        ],
+        ]
       }
     ],
     "provisioners": [

--- a/packer/vbox-redops/debian-11-redops.json
+++ b/packer/vbox-redops/debian-11-redops.json
@@ -52,8 +52,14 @@
             "{{.Name}}",
             "--cpus",
             "1"
+          ],
+          [
+            "modifyvm",
+            "{{.Name}}",
+            "--vram",
+            "32"
           ]
-        ]
+        ],
       }
     ],
     "provisioners": [

--- a/packer/vbox-redops/debian-11-redops.json
+++ b/packer/vbox-redops/debian-11-redops.json
@@ -71,14 +71,14 @@
         "execute_command": "echo 'vagrant' | {{.Vars}} sudo -S -E sh -eux '{{.Path}}'",
         "expect_disconnect": true,
         "scripts": [
-        "{{template_dir}}/scripts/update.sh",
-        "{{template_dir}}/scripts/sshd.sh",
-        "{{template_dir}}/scripts/networking.sh",
-        "{{template_dir}}/scripts/sudoers.sh",
-        "{{template_dir}}/scripts/vagrant.sh",
-        "{{template_dir}}/scripts/systemd.sh",
-        "{{template_dir}}/scripts/virtualbox.sh",
-        "{{template_dir}}/scripts/xfce-settings.sh"
+        "scripts/update.sh",
+        "scripts/sshd.sh",
+        "scripts/networking.sh",
+        "scripts/sudoers.sh",
+        "scripts/vagrant.sh",
+        "scripts/systemd.sh",
+        "scripts/virtualbox.sh",
+        "scripts/xfce-settings.sh"
         ]
       },
       
@@ -89,7 +89,10 @@
       },
       {
         "type": "shell",
-        "scripts": "scripts/cleanup.sh",
+        "scripts": [
+        "scripts/xfce-settings.sh",
+        "scripts": "scripts/cleanup.sh"
+        ],
         "execute_command": "echo 'packer' | sudo -S sh -c '{{ .Vars }} {{ .Path }}'"
       }
     ],

--- a/packer/vbox-redops/debian-11-redops.json
+++ b/packer/vbox-redops/debian-11-redops.json
@@ -77,7 +77,8 @@
         "{{template_dir}}/scripts/sudoers.sh",
         "{{template_dir}}/scripts/vagrant.sh",
         "{{template_dir}}/scripts/systemd.sh",
-        "{{template_dir}}/scripts/virtualbox.sh"
+        "{{template_dir}}/scripts/virtualbox.sh",
+        "{{template_dir}}/scripts/xfce-settings.sh
         ]
       },
       

--- a/packer/vbox-redops/debian-11-redops.json
+++ b/packer/vbox-redops/debian-11-redops.json
@@ -77,7 +77,8 @@
         "{{template_dir}}/scripts/sudoers.sh",
         "{{template_dir}}/scripts/vagrant.sh",
         "{{template_dir}}/scripts/systemd.sh",
-        "{{template_dir}}/scripts/virtualbox.sh"
+        "{{template_dir}}/scripts/virtualbox.sh",
+        "{{template_dir}}/scripts/xfce-settings.sh"
         ]
       },
       

--- a/packer/vbox-redops/debian-11-redops.json
+++ b/packer/vbox-redops/debian-11-redops.json
@@ -29,9 +29,9 @@
       "headless": true,
       "http_directory": "http",
       "iso_urls": [
-        "http://cdimage.debian.org/cdimage/release/11.0/amd64/iso-cd/debian-11.10.0-amd64-netinst.iso"
+        "https://cdimage.debian.org/debian-cd/current/amd64/iso-cd/debian-11.0.0-amd64-netinst.iso"
       ],
-        "iso_checksum": "c433254a7c5b5b9e6a05f9e1379a0bd6ab3323f89b56537b684b6d1bd1f8b6ad",
+        "iso_checksum": "ae6d563d2444665316901fe7091059ac34b8f67ba30f9159f7cef7d2fdc5bf8a",
         "ssh_username": "vagrant",
         "ssh_password": "vagrant",
         "ssh_port": 22,

--- a/packer/vbox-redops/debian-11-redops.json
+++ b/packer/vbox-redops/debian-11-redops.json
@@ -1,0 +1,96 @@
+{
+  "variables": {
+    "version": "6.1.26"
+  },
+  "builders": [
+    {
+      "type": "virtualbox-iso",
+      "boot_command": [
+        "<esc><wait>",
+        "install <wait>",
+        "preseed/url=http://{{ .HTTPIP }}:{{ .HTTPPort }}/preseed.cfg <wait>",
+        "debian-installer=en_US.UTF-8 <wait>",
+        "auto <wait>",
+        "locale=en_US.UTF-8 <wait>",
+        "kbd-chooser/method=us <wait>",
+        "keyboard-configuration/xkb-keymap=us <wait>",
+        "netcfg/get_hostname={{ .Name }} <wait>",
+        "netcfg/get_domain=thremulator.io <wait>",
+        "fb=false <wait>",
+        "debconf/frontend=noninteractive <wait>",
+        "console-setup/ask_detect=false <wait>",
+        "console-keymaps-at/keymap=us <wait>",
+        "grub-installer/bootdev=/dev/sda <wait>",
+        "<enter><wait>"
+      ],
+      "boot_wait": "10s",
+      "disk_size": 81920,
+      "guest_os_type": "Debian_64",
+      "headless": true,
+      "http_directory": "http",
+      "iso_urls": [
+        "http://cdimage.debian.org/cdimage/release/11.0/amd64/iso-cd/debian-11.10.0-amd64-netinst.iso"
+      ],
+        "iso_checksum": "c433254a7c5b5b9e6a05f9e1379a0bd6ab3323f89b56537b684b6d1bd1f8b6ad",
+        "ssh_username": "vagrant",
+        "ssh_password": "vagrant",
+        "ssh_port": 22,
+        "ssh_wait_timeout": "1800s",
+        "shutdown_command": "echo 'vagrant'|sudo -S /sbin/halt -h -p",
+        "guest_additions_path": "VBoxGuestAdditions_{{.Version}}.iso",
+        "virtualbox_version_file": ".vbox_version",
+        "vm_name": "packer-debian11-redops",
+        "vboxmanage": [
+          [
+            "modifyvm",
+            "{{.Name}}",
+            "--memory",
+            "1024"
+          ],
+          [
+            "modifyvm",
+            "{{.Name}}",
+            "--cpus",
+            "1"
+          ]
+        ]
+      }
+    ],
+    "provisioners": [
+      { 
+        "environment_vars": [
+        "HOME_DIR=/home/vagrant"
+        ],
+        "type": "shell",
+        "execute_command": "echo 'vagrant' | {{.Vars}} sudo -S -E sh -eux '{{.Path}}'",
+        "expect_disconnect": true,
+        "scripts": [
+        "{{template_dir}}/scripts/update.sh",
+        "{{template_dir}}/scripts/sshd.sh",
+        "{{template_dir}}/scripts/networking.sh",
+        "{{template_dir}}/scripts/sudoers.sh",
+        "{{template_dir}}/scripts/vagrant.sh",
+        "{{template_dir}}/scripts/systemd.sh",
+        "{{template_dir}}/scripts/virtualbox.sh"
+        ]
+      },
+      
+      {
+        "type": "ansible",
+        "playbook_file": "ansible/debian11-redops-playbook.yml"
+        
+      },
+      {
+        "type": "shell",
+        "scripts": "scripts/cleanup.sh",
+        "execute_command": "echo 'packer' | sudo -S sh -c '{{ .Vars }} {{ .Path }}'"
+      }
+    ],
+    "post-processors": [
+      {
+        "type": "vagrant",
+        "compression_level": "8",
+        "output": "../_output/{{.Provider}}-dev-debian11-red-{{timestamp}}.box"
+      }
+    ]
+  }

--- a/packer/vbox-redops/debian-11-redops.json
+++ b/packer/vbox-redops/debian-11-redops.json
@@ -77,8 +77,7 @@
         "{{template_dir}}/scripts/sudoers.sh",
         "{{template_dir}}/scripts/vagrant.sh",
         "{{template_dir}}/scripts/systemd.sh",
-        "{{template_dir}}/scripts/virtualbox.sh",
-        "{{template_dir}}/scripts/xfce-settings.sh
+        "{{template_dir}}/scripts/virtualbox.sh"
         ]
       },
       

--- a/packer/vbox-redops/http/preseed.cfg
+++ b/packer/vbox-redops/http/preseed.cfg
@@ -1,0 +1,47 @@
+choose-mirror-bin mirror/http/proxy string
+d-i apt-setup/use_mirror boolean true
+d-i base-installer/kernel/override-image string linux-server
+d-i clock-setup/utc boolean true
+d-i clock-setup/utc-auto boolean true
+d-i finish-install/reboot_in_progress note
+d-i grub-installer/only_debian boolean true
+d-i grub-installer/with_other_os boolean true
+d-i keymap select us
+d-i mirror/country string manual
+d-i mirror/http/directory string /debian
+d-i mirror/http/hostname string httpredir.debian.org
+d-i mirror/http/proxy string
+d-i partman-auto-lvm/guided_size string max
+d-i partman-auto/choose_recipe select atomic
+d-i partman-auto/method string lvm
+d-i partman-lvm/confirm boolean true
+d-i partman-lvm/confirm_nooverwrite boolean true
+d-i partman-lvm/device_remove_lvm boolean true
+d-i partman/choose_partition select finish
+d-i partman/confirm boolean true
+d-i partman/confirm_nooverwrite boolean true
+d-i partman/confirm_write_new_label boolean true
+d-i passwd/root-login boolean false
+d-i passwd/root-password-again password vagrant
+d-i passwd/root-password password vagrant
+d-i passwd/user-fullname string vagrant
+d-i passwd/user-uid string 1000
+d-i passwd/user-password password vagrant
+d-i passwd/user-password-again password vagrant
+d-i passwd/username string vagrant
+d-i pkgsel/include string sudo bzip2 acpid cryptsetup zlib1g-dev wget curl dkms fuse make nfs-common net-tools cifs-utils rsync
+d-i pkgsel/install-language-support boolean false
+d-i pkgsel/update-policy select none
+d-i pkgsel/upgrade select full-upgrade
+# Prevent packaged version of VirtualBox Guest Additions being installed:
+d-i preseed/early_command string sed -i \
+  '/in-target/idiscover(){/sbin/discover|grep -v VirtualBox;}' \
+  /usr/lib/pre-pkgsel.d/20install-hwpackages
+d-i time/zone string UTC
+d-i user-setup/allow-password-weak boolean true
+d-i user-setup/encrypt-home boolean false
+d-i preseed/late_command string sed -i '/^deb cdrom:/s/^/#/' /target/etc/apt/sources.list
+apt-cdrom-setup apt-setup/cdrom/set-first boolean false
+apt-mirror-setup apt-setup/use_mirror boolean true
+popularity-contest popularity-contest/participate boolean false
+tasksel tasksel/first multiselect standard, ssh-server

--- a/packer/vbox-redops/scripts/cleanup.sh
+++ b/packer/vbox-redops/scripts/cleanup.sh
@@ -1,0 +1,43 @@
+#!/bin/bash -ux
+
+set -o pipefail
+
+# reference: https://github.com/lavabit/robox/blob/master/scripts/common/zerodisk.sh
+
+printf 'Clean Yum'
+yum clean all
+
+printf 'Cleanup bash history'
+unset HISTFILE
+[ -f /root/.bash_history ] && rm /root/.bash_history
+[ -f /home/vagrant/.bash_history ] && rm /home/vagrant/.bash_history
+ 
+printf 'Cleanup log files'
+sudo find /var/log -type f | while read f; do echo -ne '' > $f; done
+
+
+# Whiteout root
+rootcount=$(df --sync -kP / | tail -n1  | awk -F ' ' '{print $4}')
+rootcount=$(($rootcount-1))
+dd if=/dev/zero of=/zerofill bs=1K count=$rootcount || echo "dd exit code $? suppressed"
+rm --force /zerofill
+
+
+# Whiteout boot if the block count is different then root, otherwise if the
+# block counts are identical, we assume both folders are on the same parition
+bootcount=$(df --sync -kP /boot | tail -n1 | awk -F ' ' '{print $4}')
+bootcount=$(($bootcount-1))
+if [ $rootcount != $bootcount ]; then
+  dd if=/dev/zero of=/boot/zerofill bs=1K count=$bootcount || echo "dd exit code $? suppressed"
+  rm --force /boot/zerofill
+fi
+
+
+# Sync to ensure that the delete completes before we move to the shutdown phase.
+sync
+sync
+sync
+
+
+echo "Disk Cleanup Complete"
+exit 0

--- a/packer/vbox-redops/scripts/networking.sh
+++ b/packer/vbox-redops/scripts/networking.sh
@@ -1,0 +1,9 @@
+#!/bin/sh -eux
+
+# Disable Predictable Network Interface names and use eth0
+sed -i 's/en[[:alnum:]]*/eth0/g' /etc/network/interfaces;
+sed -i 's/GRUB_CMDLINE_LINUX="\(.*\)"/GRUB_CMDLINE_LINUX="net.ifnames=0 biosdevname=0 \1"/g' /etc/default/grub;
+update-grub;
+
+# Adding a 2 sec delay to the interface up, to make the dhclient happy
+echo "pre-up sleep 2" >> /etc/network/interfaces

--- a/packer/vbox-redops/scripts/sshd.sh
+++ b/packer/vbox-redops/scripts/sshd.sh
@@ -1,0 +1,20 @@
+#!/bin/sh -eux
+
+SSHD_CONFIG="/etc/ssh/sshd_config"
+
+# ensure that there is a trailing newline before attempting to concatenate
+sed -i -e '$a\' "$SSHD_CONFIG"
+
+USEDNS="UseDNS no"
+if grep -q -E "^[[:space:]]*UseDNS" "$SSHD_CONFIG"; then
+    sed -i "s/^\s*UseDNS.*/${USEDNS}/" "$SSHD_CONFIG"
+else
+    echo "$USEDNS" >>"$SSHD_CONFIG"
+fi
+
+GSSAPI="GSSAPIAuthentication no"
+if grep -q -E "^[[:space:]]*GSSAPIAuthentication" "$SSHD_CONFIG"; then
+    sed -i "s/^\s*GSSAPIAuthentication.*/${GSSAPI}/" "$SSHD_CONFIG"
+else
+    echo "$GSSAPI" >>"$SSHD_CONFIG"
+fi

--- a/packer/vbox-redops/scripts/sudoers.sh
+++ b/packer/vbox-redops/scripts/sudoers.sh
@@ -1,0 +1,9 @@
+#!/bin/sh -eux
+
+# Only add the secure path line if it is not already present
+grep -q 'secure_path' /etc/sudoers \
+  || sed -i -e '/Defaults\s\+env_reset/a Defaults\tsecure_path="/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"' /etc/sudoers;
+
+# Set up password-less sudo for the vagrant user
+echo 'vagrant ALL=(ALL) NOPASSWD:ALL' >/etc/sudoers.d/99_vagrant;
+chmod 440 /etc/sudoers.d/99_vagrant;

--- a/packer/vbox-redops/scripts/systemd.sh
+++ b/packer/vbox-redops/scripts/systemd.sh
@@ -1,0 +1,4 @@
+#!/bin/sh -eux
+
+# https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=751636
+apt-get install libpam-systemd

--- a/packer/vbox-redops/scripts/update.sh
+++ b/packer/vbox-redops/scripts/update.sh
@@ -1,0 +1,28 @@
+#!/bin/sh -eux
+
+arch="`uname -r | sed 's/^.*[0-9]\{1,\}\.[0-9]\{1,\}\.[0-9]\{1,\}\(-[0-9]\{1,2\}\)-//'`"
+debian_version="`lsb_release -r | awk '{print $2}'`";
+major_version="`echo $debian_version | awk -F. '{print $1}'`";
+
+# Disable systemd apt timers/services
+systemctl stop apt-daily.timer;
+systemctl stop apt-daily-upgrade.timer;
+systemctl disable apt-daily.timer;
+systemctl disable apt-daily-upgrade.timer;
+systemctl mask apt-daily.service;
+systemctl mask apt-daily-upgrade.service;
+systemctl daemon-reload;
+
+# Disable periodic activities of apt
+cat <<EOF >/etc/apt/apt.conf.d/10periodic;
+APT::Periodic::Enable "0";
+APT::Periodic::Update-Package-Lists "0";
+APT::Periodic::Download-Upgradeable-Packages "0";
+APT::Periodic::AutocleanInterval "0";
+APT::Periodic::Unattended-Upgrade "0";
+EOF
+
+apt-get update;
+
+apt-get -y upgrade linux-image-$arch;
+apt-get -y install linux-headers-`uname -r`;

--- a/packer/vbox-redops/scripts/vagrant.sh
+++ b/packer/vbox-redops/scripts/vagrant.sh
@@ -1,0 +1,19 @@
+#!/bin/sh -eux
+
+# set a default HOME_DIR environment variable if not set
+HOME_DIR="${HOME_DIR:-/home/vagrant}";
+
+pubkey_url="https://raw.githubusercontent.com/hashicorp/vagrant/master/keys/vagrant.pub";
+mkdir -p $HOME_DIR/.ssh;
+if command -v wget >/dev/null 2>&1; then
+    wget --no-check-certificate "$pubkey_url" -O $HOME_DIR/.ssh/authorized_keys;
+elif command -v curl >/dev/null 2>&1; then
+    curl --insecure --location "$pubkey_url" > $HOME_DIR/.ssh/authorized_keys;
+elif command -v fetch >/dev/null 2>&1; then
+    fetch -am -o $HOME_DIR/.ssh/authorized_keys "$pubkey_url";
+else
+    echo "Cannot download vagrant public key";
+    exit 1;
+fi
+chown -R vagrant $HOME_DIR/.ssh;
+chmod -R go-rwsx $HOME_DIR/.ssh;

--- a/packer/vbox-redops/scripts/virtualbox.sh
+++ b/packer/vbox-redops/scripts/virtualbox.sh
@@ -1,0 +1,56 @@
+#!/bin/sh -eux
+
+# set a default HOME_DIR environment variable if not set
+HOME_DIR="${HOME_DIR:-/home/vagrant}";
+
+case "$PACKER_BUILDER_TYPE" in
+virtualbox-iso|virtualbox-ovf)
+    VER="`cat $HOME_DIR/.vbox_version`";
+    ISO="VBoxGuestAdditions_$VER.iso";
+
+    # mount the ISO to /tmp/vbox
+    mkdir -p /tmp/vbox;
+    mount -o loop $HOME_DIR/$ISO /tmp/vbox;
+
+
+    echo "installing deps necessary to compile kernel modules"
+    # We install things like kernel-headers here vs. kickstart files so we make sure we install them for the updated kernel not the stock kernel
+    if [ -f "/bin/dnf" ]; then
+        dnf install -y --skip-broken perl cpp gcc make bzip2 tar kernel-headers kernel-devel kernel-uek-devel || true # not all these packages are on every system
+    elif [ -f "/bin/yum" ] || [ -f "/usr/bin/yum" ]; then
+        yum install -y --skip-broken perl cpp gcc make bzip2 tar kernel-headers kernel-devel kernel-uek-devel || true # not all these packages are on every system
+    elif [ -f "/usr/bin/apt-get" ]; then
+        apt-get install -y build-essential dkms bzip2 tar linux-headers-`uname -r`
+    elif [ -f "/usr/bin/zypper" ]; then
+        zypper install -y perl cpp gcc make bzip2 tar kernel-default-devel
+    fi
+
+    echo "installing the vbox additions"
+    # this install script fails with non-zero exit codes for no apparent reason so we need better ways to know if it worked
+    /tmp/vbox/VBoxLinuxAdditions.run --nox11 || true
+
+    if ! modinfo vboxsf >/dev/null 2>&1; then
+         echo "Cannot find vbox kernel module. Installation of guest additions unsuccessful!"
+         exit 1
+    fi
+
+    echo "unmounting and removing the vbox ISO"
+    umount /tmp/vbox;
+    rm -rf /tmp/vbox;
+    rm -f $HOME_DIR/*.iso;
+
+    echo "removing kernel dev packages and compilers we no longer need"
+    if [ -f "/bin/dnf" ]; then
+        dnf remove -y gcc cpp kernel-headers kernel-devel kernel-uek-devel
+    elif [ -f "/bin/yum" ] || [ -f "/usr/bin/yum" ]; then
+        yum remove -y gcc cpp kernel-headers kernel-devel kernel-uek-devel
+    elif [ -f "/usr/bin/apt-get" ]; then
+        apt-get remove -y build-essential gcc g++ make libc6-dev dkms linux-headers-`uname -r`
+    elif [ -f "/usr/bin/zypper" ]; then
+        zypper -n rm -u kernel-default-devel gcc make
+    fi
+
+    echo "removing leftover logs"
+    rm -rf /var/log/vboxadd*
+    ;;
+esac

--- a/packer/vbox-redops/scripts/xfce-settings.sh
+++ b/packer/vbox-redops/scripts/xfce-settings.sh
@@ -1,0 +1,16 @@
+# Add these settings for staging when we get to Vagrant
+
+VAGRANT_HOME="/home/vagrant"
+
+touch $VAGRANT_HOME/.config/user-dirs.dirs
+
+echo "
+XDG_DESKTOP_DIR="$VAGRANT_HOME/Desktop"
+XDG_DOWNLOAD_DIR="$VAGRANT_HOME/Downloads"
+XDG_TEMPLATES_DIR="$VAGRANT_HOME/Templates"
+XDG_PUBLICSHARE_DIR="$VAGRANT_HOME/Public"
+XDG_DOCUMENTS_DIR="$VAGRANT_HOME/Documents"
+XDG_MUSIC_DIR="$VAGRANT_HOME/Music"
+XDG_PICTURES_DIR="$VAGRANT_HOME/Pictures"
+XDG_VIDEOS_DIR="$VAGRANT_HOME/Videos"
+" > $VAGRANT_HOME/.config/user-dirs.dirs

--- a/packer/vbox-redops/scripts/xfce-settings.sh
+++ b/packer/vbox-redops/scripts/xfce-settings.sh
@@ -2,6 +2,9 @@
 
 VAGRANT_HOME="/home/vagrant"
 
+mkdir $VAGRANT_HOME/{Desktop,Downloads,Templates,Public,Documents,Music,Pictures,Videos}
+chown -R $VAGRANT_HOME/*
+
 touch $VAGRANT_HOME/.config/user-dirs.dirs
 
 echo "

--- a/packer/vbox-redops/scripts/xfce-settings.sh
+++ b/packer/vbox-redops/scripts/xfce-settings.sh
@@ -2,18 +2,6 @@
 
 VAGRANT_HOME="/home/vagrant"
 
-mkdir $VAGRANT_HOME/{Desktop,Downloads,Templates,Public,Documents,Music,Pictures,Videos}
-chown -R $VAGRANT_HOME/*
-
-touch $VAGRANT_HOME/.config/user-dirs.dirs
-
-echo "
-XDG_DESKTOP_DIR="$VAGRANT_HOME/Desktop"
-XDG_DOWNLOAD_DIR="$VAGRANT_HOME/Downloads"
-XDG_TEMPLATES_DIR="$VAGRANT_HOME/Templates"
-XDG_PUBLICSHARE_DIR="$VAGRANT_HOME/Public"
-XDG_DOCUMENTS_DIR="$VAGRANT_HOME/Documents"
-XDG_MUSIC_DIR="$VAGRANT_HOME/Music"
-XDG_PICTURES_DIR="$VAGRANT_HOME/Pictures"
-XDG_VIDEOS_DIR="$VAGRANT_HOME/Videos"
-" > $VAGRANT_HOME/.config/user-dirs.dirs
+touch $VAGRANT_HOME/.xsession
+chown vagrant: $VAGRANT_HOME/.xsession && chmod +x $VAGRANT_HOME/.xsession
+echo "xfce4-session" > $VAGRANT_HOME/.xsession

--- a/packer/vbox-redops/scripts/xfce-settings.sh
+++ b/packer/vbox-redops/scripts/xfce-settings.sh
@@ -1,7 +1,26 @@
 # Add these settings for staging when we get to Vagrant
 
+echo "Setting XFCE4 session"
+
 VAGRANT_HOME="/home/vagrant"
 
 touch $VAGRANT_HOME/.xsession
 chown vagrant: $VAGRANT_HOME/.xsession && chmod +x $VAGRANT_HOME/.xsession
 echo "xfce4-session" > $VAGRANT_HOME/.xsession
+
+echo "Allowing color device for XRDP"
+
+touch /etc/polkit-1/localauthority.conf.d/02-allow-colord.conf
+
+echo "
+polkit.addRule(function(action, subject) {
+ if ((action.id == "org.freedesktop.color-manager.create-device" ||
+ action.id == "org.freedesktop.color-manager.create-profile" ||
+ action.id == "org.freedesktop.color-manager.delete-device" ||
+ action.id == "org.freedesktop.color-manager.delete-profile" ||
+ action.id == "org.freedesktop.color-manager.modify-device" ||
+ action.id == "org.freedesktop.color-manager.modify-profile") &&
+ subject.isInGroup("{users}")) {
+ return polkit.Result.YES;
+ }
+});" > /etc/polkit-1/localauthority.conf.d/02-allow-colord.conf

--- a/vagrant/Vagrantfile
+++ b/vagrant/Vagrantfile
@@ -24,7 +24,7 @@ Vagrant.configure("2") do |config|
     cfg.vm.provision "shell" do |s|
       s.path = "./scripts/install-fleet-server.sh"
       s.env = {
-          "ELASTIC_STACK_VERSION" => "7.14.1",
+          "ELASTIC_STACK_VERSION" => "7.14.0",
           "KIBANA_URL" => "http://192.168.33.10:5601",
           "KIBANA_AUTH" => "vagrant:vagrant",
           "ELASTICSEARCH_URL" => "http://192.168.33.10:9200"
@@ -36,7 +36,7 @@ Vagrant.configure("2") do |config|
     cfg.vm.provision "shell" do |s2|
       s2.path = "./scripts/setup-elastic.sh"
       s2.env = {
-        "ELASTIC_STACK_VERSION" => "7.14.1",
+        "ELASTIC_STACK_VERSION" => "7.14.0",
         "KIBANA_URL" => "http://192.168.33.10:5601",
         "KIBANA_AUTH" => "vagrant:vagrant",
         "ELASTICSEARCH_URL" => "http://192.168.33.10:9200",
@@ -94,7 +94,7 @@ Vagrant.configure("2") do |config|
     cfg.vm.provision "shell" do |s|
       s.path = "./scripts/install-ea-linux.sh"
       s.env = {
-        "ELASTIC_STACK_VERSION" => "7.14.1",
+        "ELASTIC_STACK_VERSION" => "7.14.0",
         "KIBANA_URL" => "http://192.168.33.10:5601",
         "KIBANA_AUTH" => "vagrant:vagrant",
         "FLEET_SERVER_URL" => "https://192.168.33.10:8220"
@@ -115,6 +115,8 @@ Vagrant.configure("2") do |config|
       vb.memory = 1024
       vb.cpus = 1
       vb.customize ["modifyvm", :id, "--cableconnected1", "on"]
+      #vb.customize ["modifyvm", :id, "--vrde", "on"]
+      #vb.customize ["modifyvm", :id, "--vrdeport", "43389"]
     end
     # Install Operator
     cfg.vm.provision "install-operator", type: "shell", path: "./scripts/install-operator.sh"

--- a/vagrant/Vagrantfile
+++ b/vagrant/Vagrantfile
@@ -64,6 +64,7 @@ Vagrant.configure("2") do |config|
 
     cfg.vm.provision "exprfix", type: "shell", path: "./scripts/fix-windows-expiration.ps1"
     cfg.vm.provision "shutup10", type: "shell", path: "./scripts/install-shutup10config.ps1"
+    cfg.vm.provision "download-install-pneuma-windows", type: "shell", path: "./scripts/download-pneuma-windows.ps1"
     cfg.vm.provision "installea", type: "shell", path: "./scripts/install-ea.ps1"
   end
 
@@ -83,6 +84,9 @@ Vagrant.configure("2") do |config|
       vb.customize ["modifyvm", :id, "--cableconnected1", "on"]
     end
 
+    # Setup Pneuma agent and service
+    cfg.vm.provision "download-install-pneuma-linux", type: "shell", path: "./scripts/download-pneuma-linux.sh"
+
     # Setup Auditbeat
     cfg.vm.provision "auditbeatsetup", type: "shell", path: "./scripts/setup-linux-beats.sh"
 
@@ -96,5 +100,23 @@ Vagrant.configure("2") do |config|
         "FLEET_SERVER_URL" => "https://192.168.33.10:8220"
       }
     end
+  end
+
+  config.vm.define "ts.redops" do |cfg|
+    cfg.vm.box = "debian-redops-box"
+    #cfg.vm.box_version = "0.9.30"
+    cfg.vm.hostname = "debian-redops"
+    #cfg.vbguest.auto_update = true
+    cfg.vm.synced_folder '.', '/vagrant', disabled: true
+    cfg.vm.network "private_network", ip: "192.168.33.13", auto_config: true
+    cfg.vm.network "forwarded_port", guest: 3389, host: 43389
+    cfg.vm.provider :virtualbox do |vb|
+      vb.name = "ts.redops"
+      vb.memory = 1024
+      vb.cpus = 1
+      vb.customize ["modifyvm", :id, "--cableconnected1", "on"]
+    end
+    # Install Operator
+    cfg.vm.provision "install-operator", type: "shell", path: "./scripts/install-operator.sh"
   end
 end

--- a/vagrant/Vagrantfile
+++ b/vagrant/Vagrantfile
@@ -112,11 +112,9 @@ Vagrant.configure("2") do |config|
     cfg.vm.network "forwarded_port", guest: 3389, host: 43389
     cfg.vm.provider :virtualbox do |vb|
       vb.name = "ts.redops"
-      vb.memory = 1024
-      vb.cpus = 1
+      vb.memory = 2048
+      vb.cpus = 2
       vb.customize ["modifyvm", :id, "--cableconnected1", "on"]
-      #vb.customize ["modifyvm", :id, "--vrde", "on"]
-      #vb.customize ["modifyvm", :id, "--vrdeport", "43389"]
     end
     # Install Operator
     cfg.vm.provision "install-operator", type: "shell", path: "./scripts/install-operator.sh"

--- a/vagrant/scripts/download-pneuma-linux.sh
+++ b/vagrant/scripts/download-pneuma-linux.sh
@@ -29,4 +29,6 @@ WantedBy=multi-user.target" > pneuma-agent.service
 cp pneuma-agent.service /etc/systemd/system
 
 systemctl enable pneuma-agent
-systemctl start pneuma-agent
+
+#Only enable this if you want pneuma started by default.
+#systemctl start pneuma-agent

--- a/vagrant/scripts/download-pneuma-linux.sh
+++ b/vagrant/scripts/download-pneuma-linux.sh
@@ -1,0 +1,32 @@
+#!/bin/bash
+
+PNEUMA_URL="https://s3.amazonaws.com/operator.payloads.open/payloads/pneuma/pneuma-linux"
+INSTALL_DIR="/opt/pneuma"
+SCRIPTS_DIR="/vagrant"
+
+# Stage Pneuma download
+
+cd "$(mktemp -d)"
+curl $PNEUMA_URL -o pneuma-agent
+mkdir $INSTALL_DIR
+cp pneuma-agent $INSTALL_DIR
+chmod +x $INSTALL_DIR/pneuma-agent
+
+
+
+echo "[Unit]
+Description=Pneuma-Agent
+
+[Service]
+ExecStart=/opt/pneuma/pneuma-agent -address "192.168.33.13:2323" -contact "tcp" -name "pneuma-centos7" -range "thremulation"
+Restart=on-failure
+StartLimitInterval=600
+RestartSec=15
+StartLimitBurst=16
+
+[Install]
+WantedBy=multi-user.target" > pneuma-agent.service
+cp pneuma-agent.service /etc/systemd/system
+
+systemctl enable pneuma-agent
+systemctl start pneuma-agent

--- a/vagrant/scripts/download-pneuma-windows.ps1
+++ b/vagrant/scripts/download-pneuma-windows.ps1
@@ -13,6 +13,8 @@ Write-Output "Copying Pneuma scripts"
 
 # Replace with Copy-Item
 Copy-Item "$scripts_dir\start-pneuma.ps1" "$install_dir"
+
+# Only enable this if you want Pneuma started by default
 Copy-Item "$scripts_dir\startup.cmd" "$vagrant_startup"
 
 # Start Pneuma if it is in the path
@@ -20,5 +22,7 @@ Copy-Item "$scripts_dir\startup.cmd" "$vagrant_startup"
 If (Test-Path $install_dir\pneuma-windows.exe) 
 {
     Write-Output "Pneuma found in install directory! Starting Pneuma with default parameters..."
-    Start-Process -FilePath "C:\Pneuma\pneuma-windows.exe" -ArgumentList "-address 192.168.33.13:2323 -contact tcp -name pneuma-window -range thremulation"
+    
+    # Only enable this line if you want Pneuma to start by default
+    #Start-Process -FilePath "C:\Pneuma\pneuma-windows.exe" -ArgumentList "-address 192.168.33.13:2323 -contact tcp -name pneuma-window -range thremulation"
 }

--- a/vagrant/scripts/download-pneuma-windows.ps1
+++ b/vagrant/scripts/download-pneuma-windows.ps1
@@ -1,0 +1,24 @@
+$OperatorAgentUrl = "https://s3.amazonaws.com/operator.payloads.open/payloads/pneuma/pneuma-windows.exe"
+$install_dir = "C:\Pneuma"
+$scripts_dir = "C:\vagrant\scripts"
+$vagrant_startup = "C:\Users\vagrant\AppData\Roaming\Microsoft\Windows\Start Menu\Programs\Startup"
+New-Item -Path $install_dir -Type directory | Out-Null
+
+# Download Pneuma for Windows
+
+Write-Output "Downloading Pneuma"
+Invoke-WebRequest -UseBasicParsing -Uri $OperatorAgentUrl -OutFile "$install_dir\pneuma-windows.exe"
+Write-Output "Copying Pneuma scripts"
+
+
+# Replace with Copy-Item
+Copy-Item "$scripts_dir\start-pneuma.ps1" "$install_dir"
+Copy-Item "$scripts_dir\startup.cmd" "$vagrant_startup"
+
+# Start Pneuma if it is in the path
+
+If (Test-Path $install_dir\pneuma-windows.exe) 
+{
+    Write-Output "Pneuma found in install directory! Starting Pneuma with default parameters..."
+    Start-Process -FilePath "C:\Pneuma\pneuma-windows.exe" -ArgumentList "-address 192.168.33.13:2323 -contact tcp -name pneuma-window -range thremulation"
+}

--- a/vagrant/scripts/install-operator.sh
+++ b/vagrant/scripts/install-operator.sh
@@ -12,5 +12,27 @@ cd $VAGRANT_HOME/Desktop
 mv operator.appImage Operator.appImage
 chmod +x Operator.appImage && chown vagrant: Operator.appImage
 
+
+# Dropping bootstrap script
+echo "Setting up first boot for Operator"
+mkdir /opt/operator
+cp /vagrant/bootstrap_operator.sh /opt/operator
+
+echo "[Unit]
+Description=bootstrap-operator
+ConditionPathExists=/home/vagrant/.config/Operator/login.prelude.org/settings.yml
+
+[Service]
+Type=oneshot
+ExecStart=/opt/bootstrap_operator.sh
+
+[Install]
+WantedBy=multi-user.target" > bootstrap-operator.service
+cp bootstrap-operator.service /etc/systemd/system
+
+systemctl enable bootstrap-operator
+systemctl start bootstrap-operator
+
+
 # For when Operator gets support for Debian directly
 #dpkg -i operator.deb

--- a/vagrant/scripts/install-operator.sh
+++ b/vagrant/scripts/install-operator.sh
@@ -1,0 +1,28 @@
+OPERATOR_URL="https://download.prelude.org/latest?platform=linux&variant=appImage"
+VAGRANT_HOME="/home/vagrant"
+
+# Create tmp directory if it hasn't been created yet
+
+mkdir /tmp
+chmod 1777 /tmp
+
+# Set XFCE as default for XRDP connections
+touch $VAGRANT_HOME/.Xclients
+echo "startxfce4" > $VAGRANT_HOME/.Xclients
+chmod +x $VAGRANT_HOME/.Xclients
+
+
+# Stage and download and install Operator
+cd "$(mktemp -d)"
+curl --silent -LJ $OPERATOR_URL -o operator.appImage
+cp operator.appImage $VAGRANT_HOME
+cd ..
+rm -rf "$(pwd)"
+sleep 10
+
+cd $VAGRANT_HOME
+
+chmod +x operator.appImage && chown vagrant: operator.appImage
+
+# For when Operator gets support for Debian directly
+#dpkg -i operator.deb

--- a/vagrant/scripts/install-operator.sh
+++ b/vagrant/scripts/install-operator.sh
@@ -9,8 +9,8 @@ cd "$(mktemp -d)"
 curl --silent -LJ $OPERATOR_URL -o operator.appImage
 cp operator.appImage $VAGRANT_HOME/Desktop
 cd $VAGRANT_HOME/Desktop
-mv operator.appImage Operator
-chmod +x operator.appImage && chown vagrant: operator.appImage
+mv operator.appImage Operator.appImage
+chmod +x Operator.appImage && chown vagrant: Operator.appImage
 
 # For when Operator gets support for Debian directly
 #dpkg -i operator.deb

--- a/vagrant/scripts/install-operator.sh
+++ b/vagrant/scripts/install-operator.sh
@@ -7,9 +7,9 @@ echo "Installing Operator"
 
 cd "$(mktemp -d)"
 curl --silent -LJ $OPERATOR_URL -o operator.appImage
-cp operator.appImage $VAGRANT_HOME
-cd $VAGRANT_HOME
-
+cp operator.appImage $VAGRANT_HOME/Desktop
+cd $VAGRANT_HOME/Desktop
+mv operator.appImage Operator
 chmod +x operator.appImage && chown vagrant: operator.appImage
 
 # For when Operator gets support for Debian directly

--- a/vagrant/scripts/install-operator.sh
+++ b/vagrant/scripts/install-operator.sh
@@ -1,25 +1,13 @@
 OPERATOR_URL="https://download.prelude.org/latest?platform=linux&variant=appImage"
 VAGRANT_HOME="/home/vagrant"
 
-# Create tmp directory if it hasn't been created yet
-
-mkdir /tmp
-chmod 1777 /tmp
-
-# Set XFCE as default for XRDP connections
-touch $VAGRANT_HOME/.Xclients
-echo "startxfce4" > $VAGRANT_HOME/.Xclients
-chmod +x $VAGRANT_HOME/.Xclients
-
-
 # Stage and download and install Operator
+
+echo "Installing Operator"
+
 cd "$(mktemp -d)"
 curl --silent -LJ $OPERATOR_URL -o operator.appImage
 cp operator.appImage $VAGRANT_HOME
-cd ..
-rm -rf "$(pwd)"
-sleep 10
-
 cd $VAGRANT_HOME
 
 chmod +x operator.appImage && chown vagrant: operator.appImage

--- a/vagrant/scripts/start-pneuma.ps1
+++ b/vagrant/scripts/start-pneuma.ps1
@@ -1,0 +1,1 @@
+Start-Process -FilePath "C:\Pneuma\pneuma-windows.exe" -ArgumentList "-address 192.168.33.10:2323 -contact tcp -name pneuma-window -range thremulation"

--- a/vagrant/scripts/start-pneuma.ps1
+++ b/vagrant/scripts/start-pneuma.ps1
@@ -1,1 +1,1 @@
-Start-Process -FilePath "C:\Pneuma\pneuma-windows.exe" -ArgumentList "-address 192.168.33.10:2323 -contact tcp -name pneuma-window -range thremulation"
+Start-Process -FilePath "C:\Pneuma\pneuma-windows.exe" -ArgumentList "-address 192.168.33.13:2323 -contact tcp -name pneuma-window -range thremulation"

--- a/vagrant/scripts/startup.cmd
+++ b/vagrant/scripts/startup.cmd
@@ -1,0 +1,1 @@
+powershell -ExecutionPolicy Bypass -File C:\Pneuma\start-pneuma.ps1


### PR DESCRIPTION
Still needs a little clean up here and there. But `ts.redops` on Debian is ready to go. 

Minimal Debian 11
- XCFE
- XRDP
- Prelude Operator

I recommend that we move away from XRDP in favor of VirtualBox native RDP (VRDE). Will only need to install VBox Extension Pack. 

Prelude Operator
- Currently runs as an appimage until official support for Debian packages. 
- Mounts to `/tmp/.mount{some_uid_for_Operator}`
- Operator assets are in `~/.config/Operator`
- Pneuma agents are set up and checking in but Operator's settings need to be listening on local range address (by default it is 127.0.0.1. 

Depending on the new version of Operator next week, we might have to bootstrap Operator with another script for configuring other settings by default. 