### PR TITLE
Bootstraps Operator for connections

### DIFF
--- a/vagrant/Vagrantfile
+++ b/vagrant/Vagrantfile
@@ -107,7 +107,7 @@ Vagrant.configure("2") do |config|
     #cfg.vm.box_version = "0.9.30"
     cfg.vm.hostname = "debian-redops"
     #cfg.vbguest.auto_update = true
-    cfg.vm.synced_folder '.', '/vagrant', disabled: true
+    cfg.vm.synced_folder ".", "/vagrant", type: "rsync"
     cfg.vm.network "private_network", ip: "192.168.33.13", auto_config: true
     cfg.vm.network "forwarded_port", guest: 3389, host: 43389
     cfg.vm.provider :virtualbox do |vb|

--- a/vagrant/scripts/bootstrap_operator.sh
+++ b/vagrant/scripts/bootstrap_operator.sh
@@ -1,0 +1,19 @@
+#!/bin/bash -eu
+OPERATOR_SETTINGS="/home/vagrant/.config/Operator/login.prelude.org/settings.yml"
+while true
+do
+	if [ -f "$OPERATOR_SETTINGS" ]; then
+    notify-send "Killing Operator temporarily so it will accept connections from the range.."
+    sleep 5
+	  sed -i 's/127.0.0.1/192.168.33.13/g' $OPERATOR_SETTINGS
+    ps --no-headers axk comm o pid,args | awk '$2 ~ "/tmp/"{print $1}' | xargs kill
+    notify-send "Operator killed after applying new settings! Starting again.."
+    sleep 5
+    /home/vagrant/Desktop/Operator.appImage
+    echo "Operator is back up! Happy hacking!"
+	  break
+  else
+	  echo "No settings file currently"
+  fi
+    sleep 10
+done

--- a/vagrant/scripts/install-operator.sh
+++ b/vagrant/scripts/install-operator.sh
@@ -15,24 +15,25 @@ chmod +x Operator.appImage && chown vagrant: Operator.appImage
 
 # Dropping bootstrap script
 echo "Setting up first boot for Operator"
-mkdir /opt/operator
-cp /vagrant/bootstrap_operator.sh /opt/operator
+#mkdir /opt/operator
+#chown vagrant: /opt/operator
+cp /vagrant/scripts/bootstrap_operator.sh $VAGRANT_HOME/Desktop
+chown vagrant: $VAGRANT_HOME/Desktop/bootstrap_operator.sh
 
-echo "[Unit]
-Description=bootstrap-operator
-ConditionPathExists=/home/vagrant/.config/Operator/login.prelude.org/settings.yml
+#echo "[Unit]
+#Description=Bootstrap-Operator
+#[Service]
+#ExecStart=/opt/operator/bootstrap_operator.sh
+#Restart=on-failure
+#StartLimitInterval=600
+#RestartSec=15
+#StartLimitBurst=16
+#[Install]
+#WantedBy=multi-user.target" > bootstrap-operator.service
+#cp bootstrap-operator.service /etc/systemd/system
 
-[Service]
-Type=oneshot
-ExecStart=/opt/bootstrap_operator.sh
 
-[Install]
-WantedBy=multi-user.target" > bootstrap-operator.service
-cp bootstrap-operator.service /etc/systemd/system
-
-systemctl enable bootstrap-operator
-systemctl start bootstrap-operator
-
+#bash /opt/operator/bootstrap_operator.sh
 
 # For when Operator gets support for Debian directly
 #dpkg -i operator.deb


### PR DESCRIPTION
Made some modifications to `install-operator.sh` and created a new script `bootstrap_operator.sh` that gets dropped on the Desktop. 

1. Once `ts.redops` is up, execute the bootstrap script and then execute Operator. The script will stop Operator and change the settings so that it can accepts connections on it's local IP. 

Thinking about a better way for this to be done, looking for feedback. 