### PR TITLE
Custom plugin for Operator

### DIFF
--- a/vagrant/resources/ServerChange.html
+++ b/vagrant/resources/ServerChange.html
@@ -1,0 +1,22 @@
+<div class="profile-heading-container">
+   <div class="body">
+     <strong class="profile-heading">My custom plugin</strong>
+     <p>
+       This plugin updates the settings.yml file with the ThremulationStation IP needed for the range to connect and then restart the API.
+     </p>
+   </div>
+ </div>
+
+ <div id="init-plugin">
+   <script>
+      
+    function change_settings()
+    {
+      Settings.settings.local.server = '192.168.56.13';
+      Settings.flushSettings();
+      Events.bus.emit('listeners');
+    }
+
+    setTimeout(change_settings, 15000);
+   </script>
+ </div> 

--- a/vagrant/resources/config.yml
+++ b/vagrant/resources/config.yml
@@ -1,0 +1,2 @@
+name: ServerChange
+description: Changes the Operator server

--- a/vagrant/scripts/install-operator.sh
+++ b/vagrant/scripts/install-operator.sh
@@ -1,5 +1,6 @@
 OPERATOR_URL="https://download.prelude.org/latest?platform=linux&variant=appImage"
 VAGRANT_HOME="/home/vagrant"
+PLUGIN_DIR="/home/vagrant/.config/Operator/login.prelude.org/plugins"
 
 # Stage and download and install Operator
 
@@ -13,34 +14,10 @@ mv operator.appImage Operator.appImage
 chmod +x Operator.appImage && chown vagrant: Operator.appImage
 
 
-# Dropping bootstrap script
+# Installing custom plugin
 
-echo "Setting up first boot for Operator"
-#mkdir /opt/operator
-#chown vagrant: /opt/operator
-cp /vagrant/scripts/bootstrap_operator.sh $VAGRANT_HOME/Desktop
-chown vagrant: $VAGRANT_HOME/Desktop/bootstrap_operator.sh
-chmod +x $VAGRANT_HOME/Desktop/bootstrap_operator.sh
-
-# Additionally run dos2unix in case of converstion issues.
-# https://stackoverflow.com/questions/33272542/bash-invalid-option-when-run-in-bash-script-fine-on-console
-dos2unix $VAGRANT_HOME/Desktop/bootstrap_operator.sh
-
-
-## Idea for a service. Needs some love and attention. 
-#echo "[Unit]
-#Description=Bootstrap-Operator
-#[Service]
-#ExecStart=/opt/operator/bootstrap_operator.sh
-#Restart=on-failure
-#StartLimitInterval=600
-#RestartSec=15
-#StartLimitBurst=16
-#[Install]
-#WantedBy=multi-user.target" > bootstrap-operator.service
-#cp bootstrap-operator.service /etc/systemd/system
-
-#bash /opt/operator/bootstrap_operator.sh
-
-# For when Operator gets support for Debian directly
-#dpkg -i operator.deb
+echo "Installing custom plugin for Operator"
+mkdir -p $VAGRANT_HOME/.config/Operator/login.prelude.org/plugins/ServerChange
+chown -R vagrant: $VAGRANT_HOME/.config/Operator/
+cp /vagrant/resources/{config.yml,ServerChange.html} $PLUGIN_DIR/ServerChange
+chmod +x $PLUGIN_DIR/ServerChange/ServerChange.html

--- a/vagrant/scripts/install-operator.sh
+++ b/vagrant/scripts/install-operator.sh
@@ -1,4 +1,4 @@
-OPERATOR_URL="https://download.prelude.org/latest?platform=linux&variant=appImage"
+OPERATOR_URL="https://download.prelude.org/latest?arch=x64&platform=linux&variant=appImage"
 VAGRANT_HOME="/home/vagrant"
 PLUGIN_DIR="/home/vagrant/.config/Operator/login.prelude.org/plugins"
 


### PR DESCRIPTION
Loads a custom plugin that will allow the IP address for the listener to change from localhost to the IP for the range. The API must be restarted in order for Operator to accept connections from agents via it's private IP.

- The install script for Operator drops the plugin in the Operator directory needed. 
- Removed bootstrap_operator script as it isn't needed
- Plugin is a little clunky in that it would execute alongside other plugins that are loaded. A timeout is set to prevent them from clashing. 